### PR TITLE
Update to latest rust

### DIFF
--- a/src/audio_tags.rs
+++ b/src/audio_tags.rs
@@ -29,7 +29,7 @@ use sndfile::{SndFile, Title, Copyright, Software, Artist, Comment, Date,
  *
  * If the tags doesn't exist in the sound file, the string is ~"".
  */
-#[deriving(Clone, Show, Eq)]
+#[deriving(Clone, Show, PartialEq)]
 pub struct Tags {
     /// The title of the sound as a String
     pub title: String,

--- a/src/openal.rs
+++ b/src/openal.rs
@@ -24,7 +24,7 @@
 * Bind only functions which are needed by lib sailor
 */
 
-#![allow(dead_code)]
+#![allow(dead_code, non_snake_case_functions)]
 
 
 #[link(name = "openal")]

--- a/src/record_context.rs
+++ b/src/record_context.rs
@@ -24,7 +24,7 @@
 use openal::ffi;
 
 /// The context needed to initialize a new Recorder
-#[deriving(Clone, Eq, Show)]
+#[deriving(Clone, PartialEq, Show)]
 pub struct RecordContext {
     capt_device: *ffi::ALCdevice
 }

--- a/src/sndfile.rs
+++ b/src/sndfile.rs
@@ -162,7 +162,7 @@ pub enum SeekMode {
 /// * EndianBig - Force big endian-ness
 /// * EndianCpu - Force CPU endian-ness
 #[repr(C)]
-#[deriving(Show, Clone, Ord, Eq)]
+#[deriving(Show, Clone, PartialOrd, PartialEq)]
 pub enum FormatType {
     FormatWav = ffi::SF_FORMAT_WAV as i32,
     FormatAiff = ffi::SF_FORMAT_AIFF as i32,

--- a/src/states.rs
+++ b/src/states.rs
@@ -22,7 +22,7 @@
 //! The states of a Sound or a Music
 
 /// The differents states in which a sound can be.
-#[deriving(Clone, Eq, Ord, Show)]
+#[deriving(Clone, PartialEq, PartialOrd, Show)]
 pub enum State {
     /// Initial state of the sound or music
     Initial,


### PR DESCRIPTION
Changed cases of `#[deriving(Eq)]` and `#[deriving(Ord)]` to `#[deriving(PartialEq)]` and `#[deriving(PartialOrd)]`
Added `#![allow(non_snake_case_functions)]` to src/openal.rs to suppress warnings
